### PR TITLE
Add errors field to response

### DIFF
--- a/src/GraphQLTestClient/Client.php
+++ b/src/GraphQLTestClient/Client.php
@@ -3,6 +3,8 @@
 namespace GraphQLTestClient;
 
 use PHPUnit\Framework\Assert;
+use function array_key_exists;
+use function json_encode;
 
 abstract class Client
 {
@@ -55,7 +57,7 @@ abstract class Client
         return $result;
     }
 
-    private function hasStringKeys(array $array):bool
+    private function hasStringKeys(array $array): bool
     {
         return count(array_filter(array_keys($array), 'is_string')) > 0;
     }
@@ -120,10 +122,13 @@ abstract class Client
     public function mutate(Query $query, array $multipart = null): ResponseData
     {
         $response = $this->executeQuery($this->getMutationData($query), $multipart);
+        if (array_key_exists('errors', $response)) {
+            return ResponseData::withErrors($response['data'][$query->getName()], $response['errors']);
+        }
         return new ResponseData($response['data'][$query->getName()]);
     }
 
-    public function query(Query $query):ResponseData
+    public function query(Query $query): ResponseData
     {
         $response = $this->executeQuery($this->getQueryData($query));
         return new ResponseData($response['data'][$query->getName()]);

--- a/src/GraphQLTestClient/ResponseData.php
+++ b/src/GraphQLTestClient/ResponseData.php
@@ -12,6 +12,9 @@ class ResponseData
     /** @var mixed */
     private $data;
 
+    /** @var mixed */
+    private $errors;
+
     /**
      * ResponseData constructor.
      *
@@ -23,10 +26,32 @@ class ResponseData
     }
 
     /**
+     * ResponseData constructor with errors.
+     *
+     * @param mixed $data
+     * @param mixed $errors
+     * @return self
+     */
+    public static function withErrors($data, $errors)
+    {
+        $instance = new self($data);
+        $instance->errors = $errors;
+        return $instance;
+    }
+
+    /**
      * @return mixed
      */
     public function getData()
     {
         return $this->data;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getErrors()
+    {
+        return $this->errors;
     }
 }


### PR DESCRIPTION
To make the tests more detailed, the response now has an errors field, if it is available.